### PR TITLE
feat: Parsers can push notes back to the DSLs to explain how each DSL…

### DIFF
--- a/lib/dsl_compose.rb
+++ b/lib/dsl_compose.rb
@@ -45,6 +45,8 @@ require "dsl_compose/composer"
 
 require "dsl_compose/class_coerce"
 
+require "dsl_compose/fix_heredoc_indentation"
+
 require "dsl_compose/shared_configuration"
 
 require "dsl_compose/dsls"

--- a/lib/dsl_compose/dsl.rb
+++ b/lib/dsl_compose/dsl.rb
@@ -82,7 +82,7 @@ module DSLCompose
         raise DescriptionAlreadyExistsError, "The DSL description has already been set"
       end
 
-      @description = description
+      @description = FixHeredocIndentation.fix_heredoc_indentation description
     end
 
     # Returns `true` if this DSL has a description, else false.

--- a/lib/dsl_compose/dsl/arguments/argument.rb
+++ b/lib/dsl_compose/dsl/arguments/argument.rb
@@ -120,7 +120,7 @@ module DSLCompose
             raise DescriptionAlreadyExistsError, "The description has already been set"
           end
 
-          @description = description
+          @description = FixHeredocIndentation.fix_heredoc_indentation description
         end
 
         # Returns `true` if this DSL has a description, else false.

--- a/lib/dsl_compose/dsl/dsl_method.rb
+++ b/lib/dsl_compose/dsl/dsl_method.rb
@@ -76,7 +76,7 @@ module DSLCompose
           raise DescriptionAlreadyExistsError, "The description has already been set"
         end
 
-        @description = description
+        @description = FixHeredocIndentation.fix_heredoc_indentation description
       end
 
       # Returns `true` if this DSL has a description, else false.

--- a/lib/dsl_compose/fix_heredoc_indentation.rb
+++ b/lib/dsl_compose/fix_heredoc_indentation.rb
@@ -1,0 +1,23 @@
+module DSLCompose
+  # A small helper to fix indentation and clean up whitespace in
+  # strings which were created with rubys heredoc syntax.
+  module FixHeredocIndentation
+    # This method is used to fix the indentation of heredoc strings.
+    # It will remove the leading whitespace from each line of the string
+    # and remove the leading newline from the string.
+    def self.fix_heredoc_indentation string
+      # replace all tabs with spaces
+      string = string.gsub(/\t/, "  ")
+      # remove empty lines from the start of the string
+      string = string.gsub(/\A( *\n)+/, "")
+      # remove empty lines from the end of the string
+      string = string.gsub(/( *\n)+\Z/, "")
+      # removes the number of leading spaces on the first line, from
+      # all the other lines
+      string = string.gsub(/^#{string[/\A */]}/, "")
+      # collapse lines which are next to each other onto the same line
+      # because they are really the same paragraph
+      string.gsub(/([^ \n])\n([^ \n])/, '\1 \2')
+    end
+  end
+end

--- a/lib/dsl_compose/interpreter.rb
+++ b/lib/dsl_compose/interpreter.rb
@@ -13,6 +13,21 @@ module DSLCompose
       @executions = []
     end
 
+    # the parser can provide usage notes for how this dsl is being used, these are used to
+    # generate documentation
+    def add_parser_usage_note child_class, note
+      @parser_usage_notes ||= {}
+      @parser_usage_notes[child_class] ||= []
+      @parser_usage_notes[child_class] << DSLCompose::FixHeredocIndentation.fix_heredoc_indentation(note)
+    end
+
+    # return the list of notes which describe how the parsers are using this DSL
+    def parser_usage_notes child_class
+      @parser_usage_notes ||= {}
+      @parser_usage_notes[child_class] ||= []
+      @parser_usage_notes[child_class]
+    end
+
     # Execute/process a dynamically defined DSL on a class.
     # `klass` is the class in which the DSL is being used, not
     # the class in which the DSL was defined.

--- a/lib/dsl_compose/interpreter/execution.rb
+++ b/lib/dsl_compose/interpreter/execution.rb
@@ -36,6 +36,19 @@ module DSLCompose
         end
       end
 
+      # the parser can provide usage notes for how this dsl is being used, these are used to
+      # generate documentation
+      def add_parser_usage_note note
+        @parser_usage_notes ||= []
+        @parser_usage_notes << DSLCompose::FixHeredocIndentation.fix_heredoc_indentation(note)
+      end
+
+      # return the list of notes which describe how the parsers are using this DSL
+      def parser_usage_notes
+        @parser_usage_notes ||= []
+        @parser_usage_notes
+      end
+
       private
 
       # catch and process any method calls within the DSL block

--- a/lib/dsl_compose/interpreter/execution/method_calls/method_call.rb
+++ b/lib/dsl_compose/interpreter/execution/method_calls/method_call.rb
@@ -22,6 +22,19 @@ module DSLCompose
               arguments: @arguments.to_h
             }
           end
+
+          # the parser can provide usage notes for how this dsl is being used, these are used to
+          # generate documentation
+          def add_parser_usage_note note
+            @parser_usage_notes ||= []
+            @parser_usage_notes << DSLCompose::FixHeredocIndentation.fix_heredoc_indentation(note)
+          end
+
+          # return the list of notes which describe how the parsers are using this DSL
+          def parser_usage_notes
+            @parser_usage_notes ||= []
+            @parser_usage_notes
+          end
         end
       end
     end

--- a/lib/dsl_compose/parser/for_children_of_parser.rb
+++ b/lib/dsl_compose/parser/for_children_of_parser.rb
@@ -121,6 +121,13 @@ module DSLCompose
       def for_dsl_or_inherited_dsl dsl_names, &block
         for_dsl dsl_names, on_current_class: true, on_ancestor_class: true, &block
       end
+
+      # takes a description of what this parser does and stores it against the DSL definition
+      # of the current @child_class, this is used to generate documentation for what the parser
+      # has done with the DSL
+      def description description
+        @base_class.dsls.add_parser_usage_note @child_class, description
+      end
     end
   end
 end

--- a/lib/dsl_compose/parser/for_children_of_parser/for_dsl_parser.rb
+++ b/lib/dsl_compose/parser/for_children_of_parser/for_dsl_parser.rb
@@ -108,6 +108,13 @@ module DSLCompose
         def for_method method_names, &block
           ForMethodParser.new(@base_class, @child_class, @dsl_execution, method_names, &block)
         end
+
+        # takes a description of what this parser does and stores it against the DSL definition
+        # of the current @child_class, this is used to generate documentation for what the parser
+        # has done with the DSL
+        def description description
+          @dsl_execution.add_parser_usage_note description
+        end
       end
     end
   end

--- a/lib/dsl_compose/parser/for_children_of_parser/for_dsl_parser/for_method_parser.rb
+++ b/lib/dsl_compose/parser/for_children_of_parser/for_dsl_parser/for_method_parser.rb
@@ -83,10 +83,21 @@ module DSLCompose
                   end
                 end
 
+                # set the method_call in an instance variable so that method calls to `description`
+                # from within the block will have access to it
+                @method_call = method_call
+
                 # yeild the block in the context of this class
                 instance_exec(**args, &block)
               end
             end
+          end
+
+          # takes a description of what this parser does and stores it against the DSL definition
+          # of the current @child_class, this is used to generate documentation for what the parser
+          # has done with the DSL
+          def description description
+            @method_call.add_parser_usage_note description
           end
         end
       end

--- a/sig/dsl_compose/interpreter.rbs
+++ b/sig/dsl_compose/interpreter.rbs
@@ -1,6 +1,7 @@
 # Classes
 module DSLCompose
   class Interpreter
+    @parser_usage_notes: Hash[singleton(Object), Array[String]]
     attr_reader executions: Array[Execution]
     def initialize: -> void
     def execute_dsl: (untyped klass, DSL dsl, *untyped args) -> Execution
@@ -8,5 +9,7 @@ module DSLCompose
     def dsl_executions: (Symbol dsl_name) -> Array[Execution]
     def to_h: (Symbol dsl_name) -> Hash[Symbol, Hash[Symbol, Array[Hash[Symbol, Symbol]]]]
     def executions_by_class: () -> Hash[Symbol, Hash[Symbol, Array[Hash[Symbol, Symbol]]]]
+    def add_parser_usage_note: (singleton(Object) klass, String notes) -> void
+    def parser_usage_notes: (singleton(Object) klass) -> Array[String]
   end
 end

--- a/sig/dsl_compose/interpreter/execution.rbs
+++ b/sig/dsl_compose/interpreter/execution.rbs
@@ -2,6 +2,8 @@
 module DSLCompose
   class Interpreter
     class Execution
+      @parser_usage_notes: Array[String]
+
       attr_reader dsl: DSL
       attr_reader klass: Object
       attr_reader method_calls: MethodCalls

--- a/sig/dsl_compose/interpreter/execution/method_calls/method_call.rbs
+++ b/sig/dsl_compose/interpreter/execution/method_calls/method_call.rbs
@@ -4,6 +4,9 @@ module DSLCompose
     class Execution
       class MethodCalls
         class MethodCall
+          @method_call: MethodCall
+          @parser_usage_notes: Array[String]
+
           attr_reader dsl_method: DSL::DSLMethod
           attr_reader arguments: Arguments
 

--- a/sig/dsl_compose/parser/for_children_of_parser/for_dsl_parser.rbs
+++ b/sig/dsl_compose/parser/for_children_of_parser/for_dsl_parser.rbs
@@ -20,7 +20,7 @@ module DSLCompose
         def for_method: (Array[Symbol] method_names) -> void
 
         class AllBlockParametersMustBeKeywordParametersError < StandardError
-            end
+        end
 
         class NoBlockProvided < StandardError
         end
@@ -29,7 +29,7 @@ module DSLCompose
         end
 
         class DSLNamesShouldBeSymbolsError < StandardError
-            end
+        end
       end
     end
   end

--- a/sig/dsl_compose/parser/for_children_of_parser/for_dsl_parser/for_method_parser.rbs
+++ b/sig/dsl_compose/parser/for_children_of_parser/for_dsl_parser/for_method_parser.rbs
@@ -9,6 +9,7 @@ module DSLCompose
           @dsl_execution: Interpreter::Execution
           @method_names: Array[Symbol]
           @method_name: Symbol
+          @method_call: Interpreter::Execution::MethodCalls::MethodCall
 
           def initialize: (singleton(Object) base_class, singleton(Object) child_class, Interpreter::Execution dsl_execution, Array[Symbol] method_names) -> void
 
@@ -19,7 +20,7 @@ module DSLCompose
           ) -> void
 
           class AllBlockParametersMustBeKeywordParametersError < StandardError
-                end
+          end
 
           class NoBlockProvided < StandardError
           end
@@ -28,7 +29,7 @@ module DSLCompose
           end
 
           class MethodNamesShouldBeSymbolsError < StandardError
-                end
+          end
         end
       end
     end

--- a/spec/integration/dsl_compose/parser/for_children_of_parser/for_dsl_parser/for_method_parser_spec.rb
+++ b/spec/integration/dsl_compose/parser/for_children_of_parser/for_dsl_parser/for_method_parser_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe DSLCompose::Parser::ForChildrenOfParser::ForDSLParser::ForMethodP
     create_class :TestParser, DSLCompose::Parser
   end
 
+  describe "where a DSL with a method, has the method called once" do
+    before(:each) do
+      ChildClass1.dsl_name do
+        method_name :foo, :bar
+      end
+    end
+
+    it "adds a parser note for the dsl method with the dsl method args" do
+      TestParser.for_children_of BaseClass do |child_class:|
+        for_dsl :dsl_name do |dsl_name:|
+          for_method :method_name do |method_name:, method_arg_name:, common_method_arg_name:|
+            description <<-DESCRIPTION
+              Notes on what this parser is doing, this is used for generating documentation
+            DESCRIPTION
+          end
+        end
+      end
+      expect(BaseClass.dsls.class_executions(ChildClass1).first.method_calls.method_calls.first.parser_usage_notes).to eql(["Notes on what this parser is doing, this is used for generating documentation"])
+    end
+  end
+
   describe "where a DSL is used three times, but a method is only called once" do
     before(:each) do
       ChildClass1.dsl_name

--- a/spec/integration/dsl_compose/parser/for_children_of_parser/for_dsl_parser_spec.rb
+++ b/spec/integration/dsl_compose/parser/for_children_of_parser/for_dsl_parser_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe DSLCompose::Parser::ForChildrenOfParser::ForDSLParser do
       expect(dsl_names).to eql([:dsl_name, :dsl_name])
       expect(dsl_arg_names).to eql([[:foo1], [:foo2]])
     end
+
+    it "adds a parser note for both uses of the DSL, but not for GrandchildClass which extends ChildClass1" do
+      TestParser.for_children_of BaseClass do |child_class:|
+        for_dsl :dsl_name do |dsl_name:, dsl_arg_name:|
+          description <<-DESCRIPTION
+            Notes on what this parser is doing, this is used for generating documentation
+          DESCRIPTION
+        end
+      end
+
+      expect(BaseClass.dsls.class_executions(ChildClass1).map(&:parser_usage_notes)).to eql([["Notes on what this parser is doing, this is used for generating documentation"], ["Notes on what this parser is doing, this is used for generating documentation"]])
+    end
   end
 
   describe "for different DSLs used on the same child class" do

--- a/spec/integration/dsl_compose/parser/for_children_of_parser_spec.rb
+++ b/spec/integration/dsl_compose/parser/for_children_of_parser_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe DSLCompose::Parser::ForChildrenOfParser do
     end
     expect(child_classes.sort_by(&:name)).to eql([ChildClass1, ChildClass2, GrandchildClass])
   end
+
+  it "successfully parses the DSL and adds a parser note" do
+    TestParser.for_children_of BaseClass do |child_class:|
+      description <<-DESCRIPTION
+        Notes on what this parser is doing, this is used for generating documentation
+      DESCRIPTION
+    end
+    expect(BaseClass.dsls.parser_usage_notes(ChildClass1)).to eql(["Notes on what this parser is doing, this is used for generating documentation"])
+    expect(BaseClass.dsls.parser_usage_notes(ChildClass2)).to eql(["Notes on what this parser is doing, this is used for generating documentation"])
+    expect(BaseClass.dsls.parser_usage_notes(GrandchildClass)).to eql(["Notes on what this parser is doing, this is used for generating documentation"])
+  end
 end

--- a/spec/unit/dsl_compose/fix_heredoc_indentation_spec.rb
+++ b/spec/unit/dsl_compose/fix_heredoc_indentation_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe DSLCompose::FixHeredocIndentation do
+  describe :fix_heredoc_indentation do
+    it "removes newlines and empty lines from the start and end of the string and collapses lines next to each other into paragraphs" do
+      test_string = <<-TEST_STRING
+
+
+      Foo
+      Bar
+
+      New Paragraph should be maintained
+
+      Should collapse to a single line with special chars $
+      * and so on
+
+      It should not collapse lines which have additional indentation
+        Such as this
+
+      TEST_STRING
+
+      expected_string = "Foo Bar\n\nNew Paragraph should be maintained\n\nShould collapse to a single line with special chars $ * and so on\n\nIt should not collapse lines which have additional indentation\n  Such as this"
+
+      expect(DSLCompose::FixHeredocIndentation.fix_heredoc_indentation(test_string)).to eq(expected_string)
+    end
+  end
+end

--- a/spec/unit/dsl_compose/interpreter_spec.rb
+++ b/spec/unit/dsl_compose/interpreter_spec.rb
@@ -37,6 +37,30 @@ RSpec.describe DSLCompose::Interpreter do
     end
   end
 
+  describe :parser_usage_notes do
+    it "returns an empty array" do
+      expect(interpreter.parser_usage_notes(TestClass)).to eql([])
+    end
+
+    describe "when a parser usage note has been added" do
+      before(:each) do
+        interpreter.add_parser_usage_note TestClass, "a note about this parser"
+      end
+
+      it "returns an array whch contains the expected parser note" do
+        expect(interpreter.parser_usage_notes(TestClass)).to eql(["a note about this parser"])
+      end
+    end
+  end
+
+  describe :add_parser_usage_note do
+    it "adds a parser note" do
+      expect(interpreter.parser_usage_notes(TestClass)).to eql([])
+      interpreter.add_parser_usage_note TestClass, "a note about this parser"
+      expect(interpreter.parser_usage_notes(TestClass)).to eql(["a note about this parser"])
+    end
+  end
+
   describe :class_executions do
     it "returns an empty array" do
       expect(interpreter.class_executions(TestClass)).to be_kind_of Array
@@ -98,6 +122,144 @@ RSpec.describe DSLCompose::Interpreter do
           expect(interpreter.dsl_executions(dsl.name)).to be_kind_of Array
           expect(interpreter.dsl_executions(dsl.name).count).to eq 1
           expect(interpreter.dsl_executions(dsl.name).first).to be_kind_of DSLCompose::Interpreter::Execution
+        end
+      end
+    end
+  end
+
+  describe :class_dsl_executions do
+    describe "when on_current_class is true and on_ancestor_class is true" do
+      it "returns an empty array" do
+        expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, true)).to be_kind_of Array
+        expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, true)).to be_empty
+      end
+
+      describe "when an excecution has occured for a different dsl" do
+        let(:different_dsl) { DSLCompose::DSL.new :different_dsl_name, TestClass }
+
+        before(:each) do
+          create_class :DifferentTestClass
+
+          interpreter.execute_dsl DifferentTestClass, different_dsl
+        end
+
+        it "returns an empty array" do
+          expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, true)).to be_kind_of Array
+          expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, true)).to be_empty
+        end
+
+        describe "when an excecution has occured for this dsl" do
+          before(:each) do
+            interpreter.execute_dsl TestClass, dsl
+          end
+
+          it "returns an array with the expected executions" do
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, true)).to be_kind_of Array
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, true).count).to eq 1
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, true).first).to be_kind_of DSLCompose::Interpreter::Execution
+          end
+
+          describe "when an excecution has occured for this dsl on a class which is an ansestor of the provided class" do
+            before(:each) do
+              create_class :ChildClass, TestClass
+            end
+
+            it "returns an array with the expected executions" do
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, false, true)).to be_kind_of Array
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, false, true).count).to eq 1
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, false, true).first).to be_kind_of DSLCompose::Interpreter::Execution
+            end
+          end
+        end
+      end
+    end
+
+    describe "when on_current_class is false and on_ancestor_class is true" do
+      it "returns an empty array" do
+        expect(interpreter.class_dsl_executions(TestClass, dsl.name, false, true)).to be_kind_of Array
+        expect(interpreter.class_dsl_executions(TestClass, dsl.name, false, true)).to be_empty
+      end
+
+      describe "when an excecution has occured for a different dsl" do
+        let(:different_dsl) { DSLCompose::DSL.new :different_dsl_name, TestClass }
+
+        before(:each) do
+          create_class :DifferentTestClass
+
+          interpreter.execute_dsl DifferentTestClass, different_dsl
+        end
+
+        it "returns an empty array" do
+          expect(interpreter.class_dsl_executions(TestClass, dsl.name, false, true)).to be_kind_of Array
+          expect(interpreter.class_dsl_executions(TestClass, dsl.name, false, true)).to be_empty
+        end
+
+        describe "when an excecution has occured for this dsl" do
+          before(:each) do
+            interpreter.execute_dsl TestClass, dsl
+          end
+
+          it "returns an empty array" do
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, false, true)).to be_kind_of Array
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, false, true)).to be_empty
+          end
+
+          describe "when an excecution has occured for this dsl on a class which is an ansestor of the provided class" do
+            before(:each) do
+              create_class :ChildClass, TestClass
+            end
+
+            it "returns an array with the expected executions" do
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, false, true)).to be_kind_of Array
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, false, true).count).to eq 1
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, false, true).first).to be_kind_of DSLCompose::Interpreter::Execution
+            end
+          end
+        end
+      end
+    end
+
+    describe "when on_current_class is true and on_ancestor_class is false" do
+      it "returns an empty array" do
+        expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, false)).to be_kind_of Array
+        expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, false)).to be_empty
+      end
+
+      describe "when an excecution has occured for a different dsl" do
+        let(:different_dsl) { DSLCompose::DSL.new :different_dsl_name, TestClass }
+
+        before(:each) do
+          create_class :DifferentTestClass
+
+          interpreter.execute_dsl DifferentTestClass, different_dsl
+        end
+
+        it "returns an empty array" do
+          expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, false)).to be_kind_of Array
+          expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, false)).to be_empty
+        end
+
+        describe "when an excecution has occured for this dsl" do
+          before(:each) do
+            interpreter.execute_dsl TestClass, dsl
+          end
+
+          it "returns an array with the expected executions" do
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, false)).to be_kind_of Array
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, false).count).to eq 1
+            expect(interpreter.class_dsl_executions(TestClass, dsl.name, true, false).first).to be_kind_of DSLCompose::Interpreter::Execution
+          end
+
+          describe "when an excecution has occured for this dsl on a class which is an ansestor of the provided class" do
+            before(:each) do
+              create_class :ChildClass, TestClass
+            end
+
+            it "returns an empty array" do
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, true, false)).to be_kind_of Array
+              expect(interpreter.class_dsl_executions(ChildClass, dsl.name, true, false)).to be_empty
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
… is being used. These notes can be used in generated documentation.