### PR TITLE
fix: for_children_of returns classes with dependencies before classes…

### DIFF
--- a/lib/dsl_compose/parser/for_children_of_parser/descendents.rb
+++ b/lib/dsl_compose/parser/for_children_of_parser/descendents.rb
@@ -14,9 +14,9 @@ module DSLCompose
           extending_classes = ObjectSpace.each_object(Class).select { |klass| klass < @base_class }
 
           # sort the results, classes are ordered first by the depth of their namespace, and second
-          # by their name
+          # by the presence of decendents and finally by their name
           extending_classes.sort_by! do |child_class|
-            "#{child_class.name.split("::").count}_#{child_class.name}"
+            "#{child_class.name.split("::").count}_#{has_descendents(child_class) ? 0 : 1}_#{child_class.name}"
           end
 
           # if this is not a final child, but we are processing final children only, then skip it

--- a/spec/unit/dsl_compose/parser/for_children_of_parser/descendents_spec.rb
+++ b/spec/unit/dsl_compose/parser/for_children_of_parser/descendents_spec.rb
@@ -6,55 +6,78 @@ RSpec.describe DSLCompose::Parser::ForChildrenOfParser::Descendents do
   before(:each) do
     # note, these are deliberately created in a non natural order, so we can
     # properly test the sorting
-    create_class "BaseClass3"
-    create_class "BaseClass1"
-    create_class "BaseClass2"
+    create_class "BaseClass"
 
-    create_class "BaseClass1::Child1", BaseClass1
+    create_class "BaseClass3", BaseClass
+    create_class "BaseClass1", BaseClass
+    create_class "BaseClass2", BaseClass
 
-    create_class "BaseClass1::Child1::Grandchild1", BaseClass1::Child1
+    create_class "BaseClass1::Child1", BaseClass
+    create_class "BaseClass1::Adult1", BaseClass
+    create_class "BaseClass1::Admin1", BaseClass1::Adult1
 
-    create_class "BaseClass2::Child1", BaseClass2
+    create_class "BaseClass1::Child1::Grandchild1", BaseClass
 
-    create_class "BaseClass1::Child2", BaseClass1
+    create_class "BaseClass2::Child1", BaseClass
 
-    create_class "BaseClass3::Child1", BaseClass3
+    create_class "BaseClass1::Child2", BaseClass
 
-    create_class "BaseClass1::Child2::Grandchild2", BaseClass1::Child2
+    create_class "BaseClass3::Child1", BaseClass
 
-    create_class "BaseClass1::Child2::Grandchild1", BaseClass1::Child2
+    create_class "BaseClass1::Child2::Grandchild2", BaseClass
 
-    create_class "BaseClass1::Child2::Grandchild2::GreatGrandhild1", BaseClass1::Child2::Grandchild2
+    create_class "BaseClass1::Child2::Grandchild1", BaseClass
+
+    create_class "BaseClass1::Child2::Grandchild2::GreatGrandhild1", BaseClass
   end
 
   describe :initialize do
     it "initializes the class without error" do
       expect {
-        DSLCompose::Parser::ForChildrenOfParser::Descendents.new BaseClass1, true
+        DSLCompose::Parser::ForChildrenOfParser::Descendents.new BaseClass, true
       }.to_not raise_error
     end
   end
 
   describe :classes do
     describe "when final_children_only is true" do
-      let(:descendants) { DSLCompose::Parser::ForChildrenOfParser::Descendents.new BaseClass1, true }
+      let(:descendants) { DSLCompose::Parser::ForChildrenOfParser::Descendents.new BaseClass, true }
 
       it "returns the expected classes in the expected order" do
         expect(descendants.classes).to eql([
+          BaseClass1,
+          BaseClass2,
+          BaseClass3,
+          BaseClass1::Admin1,
+          BaseClass1::Child1,
+          BaseClass1::Child2,
+          BaseClass2::Child1,
+          BaseClass3::Child1,
           BaseClass1::Child1::Grandchild1,
           BaseClass1::Child2::Grandchild1,
+          BaseClass1::Child2::Grandchild2,
           BaseClass1::Child2::Grandchild2::GreatGrandhild1
         ])
       end
     end
 
     describe "when final_children_only is false" do
-      let(:descendants) { DSLCompose::Parser::ForChildrenOfParser::Descendents.new BaseClass1, false }
+      let(:descendants) { DSLCompose::Parser::ForChildrenOfParser::Descendents.new BaseClass, false }
 
       it "returns the expected classes in the expected order" do
         expect(descendants.classes).to eql([
+          BaseClass1,
+          BaseClass2,
+          BaseClass3,
+          # note that Adult normally comes after Admin (alphabetically), but
+          # because Admin is a child of Adult (Adult has dependencies), it
+          # comes first
+          BaseClass1::Adult1,
+          BaseClass1::Admin1,
           BaseClass1::Child1,
           BaseClass1::Child2,
+          BaseClass2::Child1,
+          BaseClass3::Child1,
           BaseClass1::Child1::Grandchild1,
           BaseClass1::Child2::Grandchild1,
           BaseClass1::Child2::Grandchild2,


### PR DESCRIPTION
… without any dependencies, this fixes a bug where the parser is used to create other classes, and classes with dependencies need to be created first